### PR TITLE
Deployment script - RBAC Storage Blob Data Contributor #19

### DIFF
--- a/environment_preparation/deployment/deploy.sh
+++ b/environment_preparation/deployment/deploy.sh
@@ -46,14 +46,21 @@ echo "Open your Azure Synapse Workspace Web URL in the browser: $WorkspaceWeb"
 
 spID=$(az resource list -n $SynapseWorkspaceName --query [*].identity.principalId --out tsv)
 
-echo "Storage Account SP ID: $spID"
+echo "Synapse Workspace SP ID: $spID"
 
 az role assignment create \
     --assignee $spID \
     --role 'Storage Account Contributor' \
     --scope /subscriptions/$SubscriptionId/resourceGroups/$StorageAccountResourceGroup/providers/Microsoft.Storage/storageAccounts/$StorageAccountName
 
-echo "Assigned Workspace role to Storage Account"
+echo "Assigned Workspace to Storage Account as Storage Account Contributor"
+
+az role assignment create \
+    --assignee $spID \
+    --role 'Storage Blob Data Contributor' \
+    --scope /subscriptions/$SubscriptionId/resourceGroups/$StorageAccountResourceGroup/providers/Microsoft.Storage/storageAccounts/$StorageAccountName
+
+echo "Assigned Workspace to Storage Account as Storage Blob Data Contributor"
 
 userID=$(az ad signed-in-user show --query id --out tsv)
 
@@ -64,7 +71,14 @@ az role assignment create \
     --role 'Storage Account Contributor' \
     --scope /subscriptions/$SubscriptionId/resourceGroups/$StorageAccountResourceGroup/providers/Microsoft.Storage/storageAccounts/$StorageAccountName
 
-echo "Assigned User as Storage Account Contributor for Workspace"
+echo "Assigned User as Storage Account Contributor Role to Storage Account"
+
+az role assignment create \
+    --assignee $userID \
+    --role 'Storage Blob Data Contributor' \
+    --scope /subscriptions/$SubscriptionId/resourceGroups/$StorageAccountResourceGroup/providers/Microsoft.Storage/storageAccounts/$StorageAccountName
+
+echo "Assigned User as Storage Blob Data Contributor Role to Storage Account"
 
 az synapse spark pool create \
   --name "DataDiscovery" \


### PR DESCRIPTION
* Add role assignment `Storage Blob Data Contributor` for current user and Synapse workspace ID to the provided Storage account

Note it might be OK to remove the existing assignments for role `Storage Account Contributor` from the script but I'm not entirely sure this is required for other interactions by Synapse or notebooks. For now, left those assignments as-is.